### PR TITLE
Allow chrome to use the addon (in URL-only mode for now)

### DIFF
--- a/html/popup.js
+++ b/html/popup.js
@@ -10,7 +10,7 @@ if(typeof browser==="undefined") browser = chrome;
 	if(typeof chrome==="undefined"){//Firefox returns a promise that is resolved when data is set
 		return browser.storage.local.set(entries);
 	}else{//Chrome requires a callback function for when the data is set
-		return new Promise(resolve => chrome.storage.local.get(entries, resolve));
+		return new Promise(resolve => chrome.storage.local.set(entries, resolve));
 	}
   }
 

--- a/html/popup.js
+++ b/html/popup.js
@@ -1,3 +1,19 @@
+if(typeof browser==="undefined") browser = chrome;
+  function getStorageItem(keyname){
+	if(typeof chrome==="undefined"){//Firefox returns a promise that is resolved when data is retrieved. items = {keyname : value, ...}
+		return browser.storage.local.get(keyname);
+	}else{//Chrome requires a callback function for when the data is retrieved: items = {keyname : value, ...}
+		return new Promise(resolve => chrome.storage.local.get(keyname, resolve));
+	}
+  }
+  function setStorageItem(entries){
+	if(typeof chrome==="undefined"){//Firefox returns a promise that is resolved when data is set
+		return browser.storage.local.set(entries);
+	}else{//Chrome requires a callback function for when the data is set
+		return new Promise(resolve => chrome.storage.local.get(entries, resolve));
+	}
+  }
+
 
 function updateButton(enabled) {
   let button = document.getElementById("toggle-button");
@@ -34,11 +50,11 @@ var config = {
 
 document.addEventListener("DOMContentLoaded", async () => {
   // Loads config from storage
-  let data = await browser.storage.local.get('config');
+  let data = await getStorageItem('config');
   if (data.config)
     config = data.config;
   else
-    browser.storage.local.set({ 'config': config });
+    setStorageItem({ 'config': config });
 
   // Updates the UI accordingly
   updateMode(config.mode);
@@ -49,12 +65,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     config.mode = ev.target.value;
 
     updateMode(config.mode);
-    browser.storage.local.set({ 'config': config });
+    setStorageItem({ 'config': config });
   });
   document.getElementById("toggle-button").addEventListener('click', () => {
     config.enabled = !config.enabled;
 
     updateButton(config.enabled);
-    browser.storage.local.set({ 'config': config });
+    setStorageItem({ 'config': config });
   });
 });

--- a/src/hashing_worker.js
+++ b/src/hashing_worker.js
@@ -26,6 +26,7 @@ function foundHash(url) {
 onmessage = function(e) {
   let action = e.data.action;
   let requestId;
+  let url;
 
   switch (action) {
     case "hashing_mode":
@@ -33,11 +34,20 @@ onmessage = function(e) {
 
       break;
 
+    case "hash_url_only":
+      requestId = e.data.requestId;
+
+      // Hashes the URL
+      url = e.data.url;
+      if (HashingBox.hash(url))
+        foundHash(url);
+
+      break;
     case "init_request":
       requestId = e.data.requestId;
 
       // Hashes the URL
-      let url = e.data.url;
+      url = e.data.url;
       if (HashingBox.hash(url))
         foundHash(url);
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,4 +1,5 @@
 let notification_interval = null;
+if(typeof browser==="undefined") browser = chrome;
 
 function openInstructions(info) {
   let encoded_info = JSON.stringify(info);

--- a/src/webrequests.js
+++ b/src/webrequests.js
@@ -76,7 +76,7 @@ class Request {
 	if(typeof chrome==="undefined"){//Firefox returns a promise that is resolved when data is set
 		return browser.storage.local.set(entries);
 	}else{//Chrome requires a callback function for when the data is set
-		return new Promise(resolve => chrome.storage.local.get(entries, resolve));
+		return new Promise(resolve => chrome.storage.local.set(entries, resolve));
 	}
   }
   static async hookAll() {


### PR DESCRIPTION
This PR adds support for Chrome (tested by loading Unpackaged Extension) with restrictions:

- URLs are hashed, content hashing is not supported at this time.

Because of reused code and naming, you may wish to make changes to this PR if it needs more polish first.

The plugin is designed to [and does] continue to function in Firefox fully with my initial testing.